### PR TITLE
Fix duplicate detection

### DIFF
--- a/Sources/MapItemPicker/Controllers/MapItemController/MapItemController.swift
+++ b/Sources/MapItemPicker/Controllers/MapItemController/MapItemController.swift
@@ -13,7 +13,11 @@ class MapItemController: NSObject, ObservableObject, Identifiable {
             return false
         }
         
-        return self.item == other.item
+        return self.hashValue == other.hashValue
+    }
+    
+    override var hash: Int {
+        item.hashValue
     }
     
     @BackgroundPublished var item: MapItem

--- a/Sources/MapItemPicker/Controllers/MapItemSearchController.swift
+++ b/Sources/MapItemPicker/Controllers/MapItemSearchController.swift
@@ -90,12 +90,13 @@ class MapItemSearchController: NSObject, ObservableObject {
         guard
             let currentRegion = coordinator?.region,
             let otherItemsResultRegion,
-            let otherItemsRequestRegion
+            let otherItemsRequestRegion,
+            coordinator?.selectedMapItem == nil && coordinator?.selectedMapItemCluster == nil
         else { return }
         
         let regionChange = currentRegion.span.longitudeDelta / otherItemsRequestRegion.span.longitudeDelta
         if
-            !MKMapRect(otherItemsResultRegion).contains(MKMapPoint(currentRegion.center)) ||
+            !MKMapRect(otherItemsRequestRegion).contains(MKMapPoint(currentRegion.center)) ||
             !(0.65...1.5).contains(regionChange)
         {
             reload()

--- a/Sources/MapItemPicker/Data/MapItem/MapItem.swift
+++ b/Sources/MapItemPicker/Data/MapItem/MapItem.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import AddressBook
 import SchafKit
 
-public struct MapItem: Equatable, Hashable, Codable {
+public struct MapItem: Codable {
     public init(name: String, location: CLLocationCoordinate2D, region: CLCodableCircularRegion? = nil, featureAnnotationType: FeatureType? = nil, category: MapItemCategory? = nil, notes: String? = nil, street: String? = nil, housenumber: String? = nil, postcode: String? = nil, cityRegion: String? = nil, city: String? = nil, state: String? = nil, stateRegion: String? = nil, country: String? = nil, phone: String? = nil, website: String? = nil, wikidataBrand: String? = nil, wikipediaBrand: String? = nil, hasVegetarianFood: ExclusivityBool? = nil, hasVeganFood: ExclusivityBool? = nil, indoorSeating: PlaceBool? = nil, outdoorSeating: PlaceBool? = nil, internetAccess: InternetAccessType? = nil, smoking: PlaceBool? = nil, takeaway: ExclusivityBool? = nil, wheelchair: WheelchairBool? = nil, level: String? = nil, openingHours: OpeningHours? = nil) {
         self.name = name
         self.location = location
@@ -254,4 +254,19 @@ class MapItemMKPlacemark: MKPlacemark {
     }
     
     // TODO: Country Code
+}
+
+extension MapItem: Hashable, Equatable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(category)
+        hasher.combine(city)
+        hasher.combine(stateRegion)
+        hasher.combine(state)
+        hasher.combine(country)
+    }
+    
+    public static func ==(lhs: MapItem, rhs: MapItem) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
 }

--- a/Sources/MapItemPicker/Data/MapItem/MapItemCategory.swift
+++ b/Sources/MapItemPicker/Data/MapItem/MapItemCategory.swift
@@ -93,96 +93,177 @@ public enum MapItemCategory: String, Codable, CaseIterable, Identifiable {
     
     var nativeCategory: MKPointOfInterestCategory {
         switch self {
-        case .airport:
-            return .airport
-        case .amusementPark:
-            return .amusementPark
-        case .aquarium:
-            return .aquarium
-        case .atm:
-            return .atm
-        case .bakery:
-            return .bakery
-        case .bank:
-            return .bank
-        case .beach:
-            return .beach
-        case .brewery:
-            return .brewery
-        case .cafe:
-            return .cafe
-        case .campground:
-            return .campground
-        case .carRental:
-            return .carRental
-        case .evCharger:
-            return .evCharger
-        case .fireStation:
-            return .fireStation
-        case .fitnessCenter:
-            return .fitnessCenter
-        case .foodMarket:
-            return .foodMarket
-        case .gasStation:
-            return .gasStation
-        case .hospital:
-            return .hospital
-        case .hotel:
-            return .hotel
-        case .laundry:
-            return .laundry
-        case .library:
-            return .library
-        case .marina:
-            return .marina
-        case .movieTheater:
-            return .movieTheater
-        case .museum:
-            return .museum
-        case .nationalPark:
-            return .nationalPark
-        case .nightlife:
-            return .nightlife
-        case .park:
-            return .park
-        case .parking:
-            return .parking
-        case .pharmacy:
-            return .pharmacy
-        case .police:
-            return .police
-        case .postOffice:
-            return .postOffice
-        case .publicTransport:
-            return .publicTransport
-        case .restaurant:
-            return .restaurant
-        case .restroom:
-            return .restroom
-        case .school:
-            return .school
-        case .stadium:
-            return .stadium
-        case .store:
-            return .store
-        case .theater:
-            return .theater
-        case .university:
-            return .university
-        case .winery:
-            return .winery
-        case .zoo:
-            return .zoo
+        case .airport: .airport
+        case .amusementPark: .amusementPark
+        case .aquarium: .aquarium
+        case .atm: .atm
+        case .bakery: .bakery
+        case .bank: .bank
+        case .beach: .beach
+        case .brewery: .brewery
+        case .cafe: .cafe
+        case .campground: .campground
+        case .carRental: .carRental
+        case .evCharger: .evCharger
+        case .fireStation: .fireStation
+        case .fitnessCenter: .fitnessCenter
+        case .foodMarket: .foodMarket
+        case .gasStation: .gasStation
+        case .hospital: .hospital
+        case .hotel: .hotel
+        case .laundry: .laundry
+        case .library: .library
+        case .marina: .marina
+        case .movieTheater: .movieTheater
+        case .museum: .museum
+        case .nationalPark: .nationalPark
+        case .nightlife: .nightlife
+        case .park: .park
+        case .parking: .parking
+        case .pharmacy: .pharmacy
+        case .police: .police
+        case .postOffice: .postOffice
+        case .publicTransport: .publicTransport
+        case .restaurant: .restaurant
+        case .restroom: .restroom
+        case .school: .school
+        case .stadium: .stadium
+        case .store: .store
+        case .theater: .theater
+        case .university: .university
+        case .winery: .winery
+        case .zoo: .zoo
         }
     }
     
     public var id: String { rawValue }
     
-    var name: String {
+    public var name: String {
         "category.\(rawValue)".moduleLocalized
     }
     
-    var imageName: String {
+    public var circledImageName: String? {
+        switch self {
+        case .airport:
+            return "airplane.circle.fill"
+        case .amusementPark:
+            return nil // No equivalent for "sparkles.circle.fill"
+        case .aquarium:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return "fish.circle.fill"
+            }
+            return "mappin.circle.fill"
+        case .atm:
+            return "dollarsign.circle.fill"
+        case .bakery:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No equivalent for "birthday.cake.circle.fill"
+            }
+            return "mappin.circle.fill"
+        case .bank:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return "person.bust.circle.fill"
+            }
+            return "dollarsign.circle.fill"
+        case .beach:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No "beach.umbrella.circle.fill"
+            }
+            return "drop.circle.fill"
+        case .brewery:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No "wineglass.circle.fill"
+            }
+            return nil
+        case .cafe:
+            return nil // No "cup.and.saucer.circle.fill"
+        case .campground:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No "tent.circle.fill"
+            }
+            return nil
+        case .carRental:
+            return nil // No "car.2.circle.fill"
+        case .evCharger:
+            return nil // No "powerplug.circle.fill"
+        case .fireStation:
+            return "flame.circle.fill"
+        case .fitnessCenter:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No "dumbbell.circle.fill"
+            }
+            return nil
+        case .foodMarket:
+            return nil // No "basket.circle.fill"
+        case .gasStation:
+            return "fuelpump.circle.fill"
+        case .hospital:
+            return "cross.circle.fill"
+        case .hotel:
+            return "bed.double.circle.fill"
+        case .laundry:
+                if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+                    return "tshirt.circle.fill"
+                }
+                return nil
+        case .library:
+            return "books.vertical.circle.fill"
+        case .marina:
+            return nil // No "ferry.circle.fill"
+        case .movieTheater:
+            return "theatermasks.circle.fill"
+        case .museum:
+            return "building.columns.circle.fill"
+        case .nationalPark:
+            return "star.circle.fill"
+        case .nightlife:
+            if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, *) {
+                return "figure.dance.circle.fill"
+            }
+            return nil
+        case .park:
+            if #available(iOS 16.1, macOS 13.0, tvOS 16.1, watchOS 9.1, *) {
+                return "tree.circle.fill"
+            }
+            return "leaf.circle.fill"
+        case .parking:
+            return "parkingsign.circle.fill"
+        case .pharmacy:
+            return "pills.circle.fill"
+        case .police:
+            return "shield.circle.fill"
+        case .postOffice:
+            return "envelope.circle.fill"
+        case .publicTransport:
+            return "tram.circle.fill"
+        case .restaurant:
+            return "fork.knife.circle.fill"
+        case .restroom:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return "toilet.circle.fill"
+            }
+            return "mappin.circle.fill"
+        case .school:
+            return "graduationcap.circle.fill"
+        case .stadium:
+            return "sportscourt.circle.fill"
+        case .store:
+            return "bag.circle.fill"
+        case .theater:
+            return "theatermasks.circle.fill"
+        case .university:
+            return "graduationcap.circle.fill"
+        case .winery:
+            if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
+                return nil // No "wineglass.circle.fill"
+            }
+            return nil // No "takeoutbag.and.cup.and.straw.fill"
+        case .zoo:
+            return nil // No "tortoise.circle.fill"
+        }
+    }
+    
+    public var imageName: String {
         switch self {
         case .airport:
             return "airplane"
@@ -237,7 +318,7 @@ public enum MapItemCategory: String, Codable, CaseIterable, Identifiable {
             }
             return "sportscourt.fill"
         case .foodMarket:
-            return "fork.knife"
+            return "basket.fill"
         case .gasStation:
             return "fuelpump.fill"
         case .hospital:
@@ -303,24 +384,30 @@ public enum MapItemCategory: String, Codable, CaseIterable, Identifiable {
         }
     }
     
-    var color: UIColor {
+    public var color: UIColor {
         switch self {
-        case .bakery, .brewery, .cafe, .foodMarket, .laundry, .nightlife, .store:
-            return .orange
-        case .amusementPark, .aquarium, .movieTheater, .museum, .restaurant, .theater, .winery, .zoo:
-            return .systemPink
-        case .atm, .bank, .carRental, .police, .postOffice:
-            return .gray
-        case .airport, .fitnessCenter, .gasStation, .parking, .publicTransport, .beach, .marina:
-            return .init(red: 0.33, green: 0.33, blue: 1) // lightblue
-        case .campground, .evCharger, .nationalPark, .park, .stadium:
-            return .init(red: 0, green: 0.75, blue: 0) // darkgreen
-        case .fireStation, .hospital, .pharmacy:
-            return .red
-        case .hotel, .restroom:
-            return .purple
-        case .library, .school, .university:
-            return .brown
+            case .bakery, .brewery, .cafe, .restaurant, .nightlife:
+                return .systemOrange
+            case .laundry, .foodMarket, .store:
+                return .systemYellow
+            case .amusementPark, .aquarium, .movieTheater, .museum, .theater, .winery, .zoo:
+                return .systemPink
+            case .atm, .bank, .carRental, .police, .postOffice:
+                return .systemGray
+            case .fitnessCenter, .beach, .marina:
+                return .systemCyan
+            case .airport, .gasStation, .parking, .publicTransport:
+                return .systemBlue
+            case .evCharger:
+                return .systemMint
+            case .campground, .nationalPark, .park, .stadium:
+                return .systemGreen
+            case .fireStation, .hospital, .pharmacy:
+                return .systemRed
+            case .hotel, .restroom:
+                return .systemPurple
+            case .library, .school, .university:
+                return .systemBrown
         }
     }
 }

--- a/Sources/MapItemPicker/UI/Components/MapControllerHolder.swift
+++ b/Sources/MapItemPicker/UI/Components/MapControllerHolder.swift
@@ -53,7 +53,10 @@ struct MapControllerHolder<StandardView: View, SearchView: View>: UIViewControll
     }
     
     func refreshAnnotations(view: MKMapView) {
-        let newAnnotations: [MKAnnotation] = (coordinator.searcher.completionItems ?? coordinator.searcher.items) + annotations
+        var newAnnotations: [MKAnnotation] = (coordinator.searcher.completionItems ?? coordinator.searcher.items) + annotations
+        if let selected = coordinator.selectedMapItem, !newAnnotations.contains(annotation: selected) {
+            newAnnotations.append(selected)
+        }
         let oldAnnotations = view.annotations
         
         let annotationsToAdd = newAnnotations.filter({ !oldAnnotations.contains(annotation: $0) })
@@ -68,6 +71,11 @@ struct MapControllerHolder<StandardView: View, SearchView: View>: UIViewControll
         
         view.removeAnnotations(annotationsToRemove)
         view.addAnnotations(annotationsToAdd)
+        
+        // Sometimes the selectedAnnotation was not in the annotations before and thus has to be selected now.
+        if let selected = coordinator.selectedMapItem, annotationsToAdd.contains(annotation: selected) {
+            coordinator.reloadSelectedAnnotation()
+        }
     }
     
     func refreshOverlays(view: MKMapView) {

--- a/Sources/MapItemPicker/UI/Components/MapViewController.swift
+++ b/Sources/MapItemPicker/UI/Components/MapViewController.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import MapKit
 
 let miniDetentHeight: CGFloat = 80
-let standardDetentHeight: CGFloat = 300
+let standardDetentHeight: CGFloat = 400
 let miniDetentIdentifier = UISheetPresentationController.Detent.Identifier("mini")
 let standardDetentIdentifier = UISheetPresentationController.Detent.Identifier("standard")
 let bigDetentIdentifier = UISheetPresentationController.Detent.Identifier("big")
@@ -204,6 +204,7 @@ class MapViewController<StandardView: View, SearchView: View>: UIViewController 
         controller.modalPresentationStyle = .pageSheet
         let presentationController = controller.sheetPresentationController!
         presentationController.prefersGrabberVisible = true
+        presentationController.prefersScrollingExpandsWhenScrolledToEdge = false
         presentationController.detents = standardDetents
         presentationController.selectedDetentIdentifier = standardDetentIdentifier
         if #available(iOS 16, *) {


### PR DESCRIPTION
This fixes the crash during duplicate detection using the `.removeDuplicates()` function for map items. It also fixes other visual glitches and adds some new context to the MapItemCategory.